### PR TITLE
Update MCP Full Form in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 프로젝트 소개
 
-이 저장소는 MCP(Multi Cloud Platform)와 연동된 Rust 기반 프로젝트입니다. 
+이 저장소는 MCP(Model Context Protocol)와 연동된 Rust 기반 프로젝트입니다. 
 
 ### 주요 기능
 - Rust 기본 프로젝트 구조


### PR DESCRIPTION
Resolves #1

Changes:
- Updated MCP full form from "Multi Cloud Platform" to "Model Context Protocol"

## Motivation
The previous expansion of MCP was incorrect and needed to be updated to the correct full form.